### PR TITLE
Link to eventie page

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -111,7 +111,7 @@ tag_line: Hack, Learn, and Play on the Hawkesbury River
     <h2>Sponsors</h2>
     <p>
       We're actively seeking sponsors who want to support our amazing community.
-      Please contact <a href="mailto:keith@keithpitty.com">keith@keithpitty.com</a> if you or your organisation is able to help out!
+      Please <a href="http://eventie.io/events/4-rails-camp-sydney-2015">peruse the sponsorships that are available<a/> and contact <a href="mailto:keith@keithpitty.com">keith@keithpitty.com</a> if you or your organisation is able to help out!
     </p>
   </section>
 


### PR DESCRIPTION
Links to http://eventie.io/events/4-rails-camp-sydney-2015 page which provides prospective sponsors with details of what we need and the opportunity to register their interest in specific sponsorships.